### PR TITLE
Fix macOS installation function

### DIFF
--- a/flash
+++ b/flash
@@ -114,7 +114,7 @@ Programming:What is the best operating system?:Arch, because BTW i run Arch:999"
 # Define setup process in a function and create necessary files for user
 setup(){\
     mkdir "$DIR" && \
-    eval touch {"$EXAMPLE_DECK","$HIGH_SCORE","$REVIEW_LOG"} && \
+    touch {"$EXAMPLE_DECK","$HIGH_SCORE","$REVIEW_LOG"} && \
     echo "$DECK_TEMPLATE" >> "$EXAMPLE_DECK" && \
     echo -e "$DIR_MADE_MSG" ;}
 


### PR DESCRIPTION
Fix the setup function on macOS by removing the `eval` in the `touch`
statement. This fix worked for me on macOS 10.14.6, however, this hasn't
been tested with other versions of macOS. I checked that the script still works in
Linux as well.

Fixes #11 