### PR TITLE
Add the ability to change the FZF previewer.

### DIFF
--- a/flash
+++ b/flash
@@ -209,11 +209,11 @@ done
 
 
 # Set some parameters for preview command used by FZF
-while [[ -z $PREVIEWER_PARAMTERS ]]; do
-  case $PREVIEWER in
+while [ -z "$PREVIEWER_PARAMTERS" ]; do
+  case "$PREVIEWER" in
     bat) PREVIEWER_PARAMTERS="--theme='Solarized (dark)' --style=numbers --color=always" ;;
     cat) PREVIEWER_PARAMTERS="--number" ;;
-    *)   echo -e "$PREVIEWER is not a valid previewer. Use 'bat' or 'cat'. Falling back on default..." && read -r -s -p 'Press [Enter] to continue...' && PREVIEWER='bat' ;;
+    *)   echo -e "$PREVIEWER is not a valid previewer. Use 'bat' or 'cat'. Falling back on default...\n" && read -r -s -p 'Press [Enter] to continue...' && PREVIEWER='bat' ;;
   esac
 done
 

--- a/flash
+++ b/flash
@@ -26,6 +26,7 @@
 # USER CUSTOMIZABLE VARIABLES
     CARD_POOL_SIZE=10 # How large the pool size is for shuf to draw from
     SEARCH_DEPTH=999  # How many levels to recursively search for .csv's in .local/share/flash
+    PREVIEWER='bat'   # What fzf previewer to use when searching through decks
 
 # ANSI FOREGROUND ESCAPE COLORS
     RED='\033[0;31m'
@@ -196,18 +197,28 @@ ${LCYAN}The Scoring System:${NC}\n
 "
 }
 
-while getopts 'hiv' flag; do
+while getopts 'hivp:' flag; do
   case "${flag}" in
     h) print_usage && exit ;;
     i) print_info && exit ;;
     v) echo -e "\n${YELLOW}fla.sh Current Version:${NC} ${RED}1.1${NC}\n" && exit ;;
+    p) [[ $(command -v $OPTARG 2>&1) ]] && PREVIEWER=$OPTARG || { echo "Unable to find previewer $OPTARG. Exiting..." && exit 1 ; } ;;
     *) print_usage && exit 1 ;;
   esac
 done
 
 
-# Show pretty FZF preview of decks using BAT
-    DECK="$(find . -maxdepth "$SEARCH_DEPTH" -iname "*.csv" | fzf --preview='bat --theme="Solarized (dark)" --style=numbers --color=always {} | head -500')"
+# Set some parameters for preview command used by FZF
+while [[ -z $PREVIEWER_PARAMTERS ]]; do
+  case $PREVIEWER in
+    bat) PREVIEWER_PARAMTERS="--theme='Solarized (dark)' --style=numbers --color=always" ;;
+    cat) PREVIEWER_PARAMTERS="--number" ;;
+    *)   echo -e "$PREVIEWER is not a valid previewer. Use 'bat' or 'cat'. Falling back on default..." && sleep 1 && PREVIEWER='bat' ;;
+  esac
+done
+
+# Show pretty FZF preview of decks using $PREVIEWER. Default: BAT
+    DECK="$(find . -maxdepth "$SEARCH_DEPTH" -iname "*.csv" | fzf --preview="$PREVIEWER $PREVIEWER_PARAMTERS {} | head -500")"
 
 # If no deck is selected in fzf menu
 # return user to start location

--- a/flash
+++ b/flash
@@ -151,7 +151,7 @@ if [ ! -e "$REVIEW_LOG" ]; then
 fi
 
 print_usage() {
-    echo -e "\n${LCYAN}fla.sh --- Flash card system by Bryan Jenks${NC} ${LBLUE}<BryanJenks@protonmail.com>${NC}\n\n${YELLOW}${BOLD}Usage:${NC}\n\t${GREEN}flash -h:${NC} Print this help text\n\t${GREEN}flash -i:${NC} Print Information about the flashcard system\n\t${GREEN}flash -v:${NC} Print version Number\n\t${GREEN}flash -p [BINARY]:${NC} Change the previewer when selecting decks\n"
+    echo -e "\n${LCYAN}fla.sh --- Flash card system by Bryan Jenks${NC} ${LBLUE}<BryanJenks@protonmail.com>${NC}\n\n${YELLOW}${BOLD}Usage:${NC}\n\t${GREEN}flash -h:${NC} Print this help text\n\t${GREEN}flash -i:${NC} Print Information about the flashcard system\n\t${GREEN}flash -v:${NC} Print version Number\n\t${GREEN}flash -p [BINARY]:${NC} Change the previewer when selecting decks. Default: bat\n\t\tSupported: bat, cat\n"
 }
 
 print_info() {
@@ -213,7 +213,7 @@ while [[ -z $PREVIEWER_PARAMTERS ]]; do
   case $PREVIEWER in
     bat) PREVIEWER_PARAMTERS="--theme='Solarized (dark)' --style=numbers --color=always" ;;
     cat) PREVIEWER_PARAMTERS="--number" ;;
-    *)   echo -e "$PREVIEWER is not a valid previewer. Use 'bat' or 'cat'. Falling back on default..." && sleep 1 && PREVIEWER='bat' ;;
+    *)   echo -e "$PREVIEWER is not a valid previewer. Use 'bat' or 'cat'. Falling back on default..." && read -s -p 'Press [Enter] to continue...' && PREVIEWER='bat' ;;
   esac
 done
 

--- a/flash
+++ b/flash
@@ -213,7 +213,7 @@ while [[ -z $PREVIEWER_PARAMTERS ]]; do
   case $PREVIEWER in
     bat) PREVIEWER_PARAMTERS="--theme='Solarized (dark)' --style=numbers --color=always" ;;
     cat) PREVIEWER_PARAMTERS="--number" ;;
-    *)   echo -e "$PREVIEWER is not a valid previewer. Use 'bat' or 'cat'. Falling back on default..." && read -s -p 'Press [Enter] to continue...' && PREVIEWER='bat' ;;
+    *)   echo -e "$PREVIEWER is not a valid previewer. Use 'bat' or 'cat'. Falling back on default..." && read -r -s -p 'Press [Enter] to continue...' && PREVIEWER='bat' ;;
   esac
 done
 

--- a/flash
+++ b/flash
@@ -202,7 +202,7 @@ while getopts 'hivp:' flag; do
     h) print_usage && exit ;;
     i) print_info && exit ;;
     v) echo -e "\n${YELLOW}fla.sh Current Version:${NC} ${RED}1.1${NC}\n" && exit ;;
-    p) [[ $(command -v $OPTARG 2>&1) ]] && PREVIEWER=$OPTARG || { echo "Unable to find previewer $OPTARG. Exiting..." && exit 1 ; } ;;
+    p) if [[ $(command -v "$OPTARG" 2>&1) ]]; then PREVIEWER=$OPTARG; else echo "Unable to find previewer $OPTARG. Exiting..." && exit 1; fi ;;
     *) print_usage && exit 1 ;;
   esac
 done

--- a/flash
+++ b/flash
@@ -151,7 +151,7 @@ if [ ! -e "$REVIEW_LOG" ]; then
 fi
 
 print_usage() {
-    echo -e "\n${LCYAN}fla.sh --- Flash card system by Bryan Jenks${NC} ${LBLUE}<BryanJenks@protonmail.com>${NC}\n\n${YELLOW}${BOLD}Usage:${NC}\n\t${GREEN}flash -h:${NC} Print this help text\n\t${GREEN}flash -i:${NC} Print Information about the flashcard system\n\t${GREEN}flash -v:${NC} Print version Number\n\n"
+    echo -e "\n${LCYAN}fla.sh --- Flash card system by Bryan Jenks${NC} ${LBLUE}<BryanJenks@protonmail.com>${NC}\n\n${YELLOW}${BOLD}Usage:${NC}\n\t${GREEN}flash -h:${NC} Print this help text\n\t${GREEN}flash -i:${NC} Print Information about the flashcard system\n\t${GREEN}flash -v:${NC} Print version Number\n\t${GREEN}flash -p [BINARY]:${NC} Change the previewer when selecting decks\n"
 }
 
 print_info() {


### PR DESCRIPTION
This pull request adds a way of changing the FZF previewer by using the `-p` flag. An example of this might look like:

```
$ flash -p cat
```

This will use cat has the FZF previewer instead of bat. However, it keeps bat as the default program in all cases unless specifically changed by the `-p` parameter. There are also checks to see if the provided binary actually exists on the system. If it exists on the system, it checks if it supported by flash. If it isn't supported by flash, it falls back onto bat as the default previewer. For now, only bat and cat are supported but it can easily be expanded.

This should fix part of #18. If you prefer the user just edit the variables directly in the top of the script, I can remove the `-p` all together. However, editing the script directly makes it more difficult to save the configuration across multiple machines. I would like to just add an alias in my dotfiles. 

Anyways, let me know your thoughts and any changes you may want.